### PR TITLE
Add support for alfred-telemetry

### DIFF
--- a/src/main/java/eu/xenit/alfred/initializr/generator/extensions/alfred/telemetry/AlfredTelemetryProjectGenerationConfiguration.java
+++ b/src/main/java/eu/xenit/alfred/initializr/generator/extensions/alfred/telemetry/AlfredTelemetryProjectGenerationConfiguration.java
@@ -1,0 +1,72 @@
+package eu.xenit.alfred.initializr.generator.extensions.alfred.telemetry;
+
+import eu.xenit.alfred.initializr.generator.alfresco.platform.PlatformBuild;
+import eu.xenit.alfred.initializr.generator.build.BuildCustomizer;
+import eu.xenit.alfred.initializr.generator.build.RootProjectBuild;
+import eu.xenit.alfred.initializr.generator.condition.ConditionalOnRequestedFacet;
+import eu.xenit.alfred.initializr.generator.sdk.alfred.AlfredSdk;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleDependency;
+import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.initializr.generator.version.VersionReference;
+import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.initializr.metadata.support.MetadataBuildItemMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.Assert;
+
+@ProjectGenerationConfiguration
+@ConditionalOnRequestedFacet("telemetry")
+public class AlfredTelemetryProjectGenerationConfiguration {
+
+    private final InitializrMetadata metadata;
+
+    private static final String ALFRED_TELEMETRY = "alfred-telemetry";
+
+    private static final Dependency DEP_MICROMETER = Dependency
+            .withCoordinates("io.micrometer", "micrometer-core")
+            .scope(DependencyScope.PROVIDED_RUNTIME)
+            .version(VersionReference.ofValue("1.0.6"))
+            .build();
+
+    public AlfredTelemetryProjectGenerationConfiguration(InitializrMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Bean
+    @ConditionalOnBuildSystem(GradleBuildSystem.ID)
+    public BuildCustomizer<RootProjectBuild> addRootAlfredTelemetryAmp() {
+        return (build) -> {
+            io.spring.initializr.generator.buildsystem.Dependency dependency = getDependency(ALFRED_TELEMETRY);
+            GradleDependency telemetryAmp = GradleDependency.from(dependency)
+                    .type("amp")
+                    .configuration(AlfredSdk.Configurations.ALFRESCO_AMP)
+                    .build();
+
+            build.dependencies().add(ALFRED_TELEMETRY, telemetryAmp);
+        };
+    }
+
+    @Bean
+    @ConditionalOnBuildSystem(GradleBuildSystem.ID)
+    public BuildCustomizer<PlatformBuild> addPlatformMicrometerDependency() {
+        return (build) -> {
+            GradleDependency micrometer = GradleDependency
+                    .from(DEP_MICROMETER)
+                    .configuration(AlfredSdk.Configurations.ALFRESCO_PROVIDED)
+                    .build();
+
+            build.dependencies().add("micrometer", micrometer);
+        };
+    }
+
+    private Dependency getDependency(String dependencyId) {
+        io.spring.initializr.metadata.Dependency alfredTelemetryDep = metadata.getDependencies().get(dependencyId);
+        Assert.notNull(alfredTelemetryDep, "Dependency with id 'alfred-telemetry' not found");
+
+        return MetadataBuildItemMapper.toDependency(alfredTelemetryDep);
+    }
+
+}

--- a/src/main/java/eu/xenit/alfred/initializr/generator/sdk/alfred/platform/AlfredSdkPlatformModuleGradleCustomizer.java
+++ b/src/main/java/eu/xenit/alfred/initializr/generator/sdk/alfred/platform/AlfredSdkPlatformModuleGradleCustomizer.java
@@ -23,8 +23,6 @@ public class AlfredSdkPlatformModuleGradleCustomizer implements BuildCustomizer<
         build.addPlugin("eu.xenit.alfresco", "0.2.0");
         build.addPlugin("eu.xenit.amp", "0.2.0");
 
-        build.ext("alfrescoVersion", quote(this.platformModule.getAlfrescoVersion().toString()));
-
         build.dependencies().add("alfresco-repository", Dependencies.ALFRESCO_REPOSITORY);
     }
 

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -10,4 +10,5 @@ eu.xenit.alfred.initializr.generator.sdk.alfred.platform.AlfredSdkPlatformProjec
 eu.xenit.alfred.initializr.generator.sdk.alfred.docker.DockerBuildGenerationConfiguration,\
 eu.xenit.alfred.initializr.generator.sdk.alfred.docker.AlfredSdkComposeProjectGenerationConfiguration,\
 eu.xenit.alfred.initializr.generator.alfresco.platform.AlfrescoModuleProjectGenerationConfiguration,\
-eu.xenit.alfred.initializr.generator.docker.compose.DockerComposeProjectGenerationConfiguration
+eu.xenit.alfred.initializr.generator.docker.compose.DockerComposeProjectGenerationConfiguration,\
+eu.xenit.alfred.initializr.generator.extensions.alfred.telemetry.AlfredTelemetryProjectGenerationConfiguration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,3 +76,16 @@ initializr:
       artifactId: alfred-api
       version: 2.0.1-RC2
       description: Alfred API allows you to access Alfresco in a standardised way.
+
+  - name: Monitoring
+    content:
+    - id: alfred-telemetry
+      name: Alfred Telemetry
+      description: Provides metrics for Alfresco using micrometer.io, a vendor-neutral application metrics facade.
+      groupId: eu.xenit.alfred.telemetry
+      artifactId: alfred-telemetry-platform
+      type: amp
+      version: 0.1.0
+      weight: 10
+      facets:
+      - telemetry

--- a/src/test/java/eu/xenit/alfred/initializr/integration/AlfredGradleSdkTests.java
+++ b/src/test/java/eu/xenit/alfred/initializr/integration/AlfredGradleSdkTests.java
@@ -13,12 +13,13 @@ public class AlfredGradleSdkTests extends BaseGeneratorTests {
         GradleMultiProjectAssert result = generateGradleBuild(request);
 
         result.rootGradleBuild()
-                .hasPlugin("eu.xenit.docker-alfresco"); // only when we package as docker ?
+                .hasPlugin("eu.xenit.docker-alfresco") // only when we package as docker ?
+                .contains("alfrescoVersion = '5.2.5'\n");
 
         result.platformGradleBuild()
                 .hasPlugin("eu.xenit.alfresco")
                 .hasPlugin("eu.xenit.amp")
-                .contains("alfrescoVersion = '5.2.5'\n")
+
                 .hasDependency("alfrescoProvided", quote("org.alfresco:alfresco-repository:${alfrescoVersion}"));
 
     }

--- a/src/test/java/eu/xenit/alfred/initializr/integration/DockerBuildGenerationConfigurationTest.java
+++ b/src/test/java/eu/xenit/alfred/initializr/integration/DockerBuildGenerationConfigurationTest.java
@@ -14,13 +14,14 @@ public class DockerBuildGenerationConfigurationTest extends BaseGeneratorTests {
 
         result.rootGradleBuild()
                 .hasPlugin("eu.xenit.docker-alfresco")
+                .contains("alfrescoVersion = ")
                 .hasDependency(
                         "alfrescoAmp",
                         "project(path: ':demo-platform', configuration: 'amp')");
 
 
         result.platformGradleBuild()
-                .doesNotHavePlugin("eu.xenit.docker-alfresco")
-                .contains("alfrescoVersion = ");
+                .doesNotHavePlugin("eu.xenit.docker-alfresco");
+
     }
 }

--- a/src/test/java/eu/xenit/alfred/initializr/integration/extensions/AlfredTelemetryTests.java
+++ b/src/test/java/eu/xenit/alfred/initializr/integration/extensions/AlfredTelemetryTests.java
@@ -1,0 +1,25 @@
+package eu.xenit.alfred.initializr.integration.extensions;
+
+import eu.xenit.alfred.initializr.asserts.build.gradle.GradleMultiProjectAssert;
+import eu.xenit.alfred.initializr.asserts.docker.DockerComposeAssert;
+import eu.xenit.alfred.initializr.asserts.docker.DockerComposeProjectAssert;
+import eu.xenit.alfred.initializr.integration.BaseGeneratorTests;
+import io.spring.initializr.web.project.ProjectRequest;
+import org.junit.Test;
+
+public class AlfredTelemetryTests extends BaseGeneratorTests {
+
+    @Test
+    public void testAlfredTelemetryGradleDependencies() {
+        ProjectRequest request = createProjectRequest("alfred-telemetry");
+
+        GradleMultiProjectAssert result = generateGradleBuild(request);
+
+        result.rootGradleBuild()
+                .hasDependency("alfrescoAmp",
+                        quote("eu.xenit.alfred.telemetry:alfred-telemetry-platform:0.1.0@amp"));
+
+        result.platformGradleBuild()
+                .hasDependency("alfrescoProvided", quote("io.micrometer:micrometer-core:1.0.6"));
+    }
+}

--- a/src/test/java/eu/xenit/alfred/initializr/integration/extensions/AlfredTelemetryTests.java
+++ b/src/test/java/eu/xenit/alfred/initializr/integration/extensions/AlfredTelemetryTests.java
@@ -3,6 +3,7 @@ package eu.xenit.alfred.initializr.integration.extensions;
 import eu.xenit.alfred.initializr.asserts.build.gradle.GradleMultiProjectAssert;
 import eu.xenit.alfred.initializr.asserts.docker.DockerComposeAssert;
 import eu.xenit.alfred.initializr.asserts.docker.DockerComposeProjectAssert;
+import eu.xenit.alfred.initializr.generator.extensions.alfred.telemetry.AlfredTelemetryProjectGenerationConfiguration;
 import eu.xenit.alfred.initializr.integration.BaseGeneratorTests;
 import io.spring.initializr.web.project.ProjectRequest;
 import org.junit.Test;
@@ -15,11 +16,16 @@ public class AlfredTelemetryTests extends BaseGeneratorTests {
 
         GradleMultiProjectAssert result = generateGradleBuild(request);
 
+        String telemetryVersion = AlfredTelemetryProjectGenerationConfiguration.ALFRED_TELEMETRY_VERSION;
+        String micrometerVersion = AlfredTelemetryProjectGenerationConfiguration.MICROMETER_VERSION;
+
         result.rootGradleBuild()
                 .hasDependency("alfrescoAmp",
-                        quote("eu.xenit.alfred.telemetry:alfred-telemetry-platform:0.1.0@amp"));
+                        quote("eu.xenit.alfred.telemetry:alfred-telemetry-platform:${alfredTelemetryVersion}@amp"))
+                .contains("alfredTelemetryVersion = '" + telemetryVersion + "'")
+                .contains("micrometerVersion = '" + micrometerVersion + "'");
 
         result.platformGradleBuild()
-                .hasDependency("alfrescoProvided", quote("io.micrometer:micrometer-core:1.0.6"));
+                .hasDependency("alfrescoProvided", quote("io.micrometer:micrometer-core:${micrometerVersion}"));
     }
 }


### PR DESCRIPTION
This PR adds support for Alfred Telemetry.

When you add the Alfred Telemetry dependency:

1. an `alfrescoAmp` dependency on `eu.xenit.alfred.telemetry:alfred-telemetry-platform` is added in the root project, which builds the docker image.
2. in the platform-subproject, an `alfrescoProvided` dependency on `micrometer-core` is added. 
(This is optional and only relevant if you want to add application metrics in your platform-subproject. We might move that into a  separate "Micrometer API" dependency.)